### PR TITLE
Add titles to phone and email links before bigger design layout testing

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,8 +82,8 @@
         <section class="contact-me" id="contact-me">
             <h2>Contact Me</h2>
             <ul class="contact-container">
-                <li class="icons" id="phone">(720) 555-5555</li>
-                <li class="icons" id="gmail-ico">cody@email.com</li>
+                <li class="icons" id="phone" title="Phone number comign soon.">(720) 555-5555</li>
+                <li class="icons" id="gmail-ico" title="Link to email coming soon.">cody@email.com</li>
                 <li><a class="icons" href="https://github.com/chilejay7" title="Cody Burkholder's GitHub  profile."
                         id="github-ico">GitHub</a></li>
                 <li><a class="icons" href="https://www.linkedin.com/in/cody-burkholder-4b072848/"


### PR DESCRIPTION
This PR adds a small feature update to the contact me phone and email links to include descriptive titles when hovered over with the cursor.  This PR was made before testing larger design layout changes to preserve all working code in the Professional Portfolio application.