### PR TITLE
Updated targets to open in new tab

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -218,7 +218,7 @@ a {
 
 /* This adds icon links before contact me information.  The links were resized in MS Paint before adding. */ 
 
-#phone::before {
+#phone-ico::before {
     content: url(../images/phone_icon.png);
  }
 

--- a/index.html
+++ b/index.html
@@ -98,12 +98,18 @@
         <section class="contact-me" id="contact-me">
             <h2>Contact Me</h2>
             <ul class="contact-container">
-                <li class="icons" id="phone" title="Phone number comign soon.">(720) 555-5555</li>
+                <li class="icons" id="phone-ico" title="Phone number comign soon.">(720) 555-5555</li>
                 <li class="icons" id="gmail-ico" title="Link to email coming soon.">cody@email.com</li>
-                <li><a class="icons" href="https://github.com/chilejay7" title="Cody Burkholder's GitHub profile."
-                        id="github-ico">GitHub</a></li>
-                <li><a class="icons" href="https://www.linkedin.com/in/cody-burkholder-4b072848/"
-                        title="Cody Burkholder's professional LinkedIn profile." id="linkedin-ico">LinkedIn</a></li>
+
+                <li>
+                    <a class="icons" id="github-ico" href="https://github.com/chilejay7" title="Cody Burkholder's GitHub profile"
+                        target=" _blank">GitHub</a>
+                </li>
+
+                <li>
+                    <a class="icons" id="linkedin-ico" href="https://www.linkedin.com/in/cody-burkholder-4b072848/"
+                        title="Cody Burkholder's professional LinkedIn profile" target=" _blank">LinkedIn</a>
+                </li>
             </ul>
         </section>
 


### PR DESCRIPTION
This PR add target attributes to the contact section to allow the links to open in a new tab for easier evaluation of the Professional Portfolio's application.  The phone id was also updated to use the naming convention of other contact id's.