### PR TITLE
nav link hover translate value reduced

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -114,7 +114,7 @@ a {
 
 /* This gives links in the navigation menu a grey background when hovered. */
 .navigation ul li:hover {
-    transform: translate(0, -10px);
+    transform: translate(0, -5px);
 }
 
 /* This styles links so the text color does not blend into the header background after click. */


### PR DESCRIPTION
The translate hover value of the navigation list elements was reduced.  It was too pronounced.